### PR TITLE
Fix PyPy2 run on GHA.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.6"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -140,7 +140,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies
+      - name: Install Build Dependencies (PyPy2)
+        if: >
+           startsWith(matrix.python-version, 'pypy-2.7')
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine "cffi != 1.15.1"
+      - name: Install Build Dependencies (other Python versions)
+        if: >
+           !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -153,7 +161,7 @@ jobs:
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install .[test]
+          pip install --pre .[test]
 
       - name: Check zope.hookable build
         run: |
@@ -173,7 +181,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-alpha.6')
+          && !startsWith(matrix.python-version, '3.11.0-beta.3')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -195,7 +203,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.6"
+          - "3.11.0-beta.3"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -247,7 +255,7 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/zope.hookable-*whl -d src
-          pip install -U -e .[test]
+          pip install --pre -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -37,8 +37,8 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        "${PYBIN}/pip" install --pre -e /io/
+        "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           "${PYBIN}/pip" install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "863bceecb48a88d769063e4dedce3fd77d2b6187"
+commit-id = "cde9741a5a0d9d04cee25cb617ee1590afebb17d"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2 (unreleased)
 ================
 
-- Add support for Python 3.10 and 3.11 (as of 3.11.0a6).
+- Add support for Python 3.10 and 3.11 (as of 3.11.0b3).
 
 
 5.1.0 (2021-07-20)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,14 @@ ignore =
     .meta.toml
     docs/_build/html/_sources/*
     docs/_build/doctest/*
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,13 @@
 """
 import os
 import platform
-
 from distutils.errors import CCompilerError
 from distutils.errors import DistutilsExecError
 from distutils.errors import DistutilsPlatformError
 
-from setuptools import setup
-from setuptools import find_packages
 from setuptools import Extension
-
+from setuptools import find_packages
+from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
 

--- a/src/zope/hookable/tests/test_hookable.py
+++ b/src/zope/hookable/tests/test_hookable.py
@@ -38,7 +38,8 @@ class PyHookableMixin(object):
 class HookableMixin(object):
 
     def _callFUT(self, *args, **kw):
-        from zope.hookable import hookable, _py_hookable
+        from zope.hookable import _py_hookable
+        from zope.hookable import hookable
         if hookable is _py_hookable:
             raise unittest.SkipTest("Hookable and PyHookable are the same")
         return hookable(*args, **kw)  # pragma: no cover
@@ -48,8 +49,10 @@ class PyHookableTests(PyHookableMixin,
                       unittest.TestCase):
 
     def test_pure_python(self):
-        from zope.hookable import _PURE_PYTHON, hookable
-        from zope.hookable import _py_hookable, _c_hookable
+        from zope.hookable import _PURE_PYTHON
+        from zope.hookable import _c_hookable
+        from zope.hookable import _py_hookable
+        from zope.hookable import hookable
         self.assertIs(hookable, _py_hookable if _PURE_PYTHON else _c_hookable)
 
     def test_before_hook(self):

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,10 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = true
 deps =
+    # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
+    Sphinx < 5
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0
@@ -47,15 +50,25 @@ commands =
 [testenv:lint]
 basepython = python3
 skip_install = true
-deps =
-    flake8
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
 commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
     check-manifest
     check-python-versions
+deps =
+    check-manifest
+    check-python-versions >= 0.19.1
+    wheel
+    flake8
+    isort
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
* Fix isort order.
* Update to Python 3.11.0b3.