### PR TITLE
Update to the latest c-code template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +105,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -142,18 +143,19 @@ jobs:
 
       - name: Install Build Dependencies (PyPy2)
         if: >
-           startsWith(matrix.python-version, 'pypy-2.7')
+          startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine "cffi != 1.15.1"
       - name: Install Build Dependencies (other Python versions)
         if: >
-           !startsWith(matrix.python-version, 'pypy-2.7')
+          !startsWith(matrix.python-version, 'pypy-2.7')
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build zope.hookable
+      - name: Build zope.hookable (3.11.0-rc.1)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -162,6 +164,33 @@ jobs:
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install --pre .[test]
+      - name: Build zope.hookable (Python 3.10 on MacOS)
+        if: >
+          startsWith(runner.os, 'Mac')
+          && startsWith(matrix.python-version, '3.10')
+        env:
+          _PYTHON_HOST_PLATFORM: macosx-11-x86_64
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install .[test]
+
+      - name: Build zope.hookable (all other versions)
+        if: >
+          !startsWith(runner.os, 'Mac')
+          || !startsWith(matrix.python-version, '3.10')
+        run: |
+          # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
+          # output (pip install uses a random temporary directory, making this difficult).
+          python setup.py build_ext -i
+          python setup.py bdist_wheel
+          # Also install it, so that we get dependencies in the (pip) cache.
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          pip install .[test]
 
       - name: Check zope.hookable build
         run: |
@@ -181,7 +210,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.3')
+          && !startsWith(matrix.python-version, '3.11.0-rc.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -203,7 +232,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.3"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -244,7 +273,8 @@ jobs:
         with:
           name: zope.hookable-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install zope.hookable
+      - name: Install zope.hookable 3.11.0-rc.1
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -256,6 +286,17 @@ jobs:
           # might also save some build time?
           unzip -n dist/zope.hookable-*whl -d src
           pip install --pre -U -e .[test]
+      - name: Install zope.hookable
+        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.1') }}
+        run: |
+          pip install -U wheel setuptools
+          pip install -U coverage
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/zope.hookable-*whl -d src
+          pip install -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "cde9741a5a0d9d04cee25cb617ee1590afebb17d"
+commit-id = "f94fb85fc6efc10e9b24a076b78a1d11aa182039"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Add support for Python 3.10 and 3.11 (as of 3.11.0b3).
 
+- Disable unsafe math optimizations in C code.  See `pull request 25
+  <https://github.com/zopefoundation/zope.hookable/pull/25>`_.
+
 
 5.1.0 (2021-07-20)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2 (unreleased)
 ================
 
-- Add support for Python 3.10 and 3.11 (as of 3.11.0b3).
+- Add support for Python 3.10 and 3.11 (as of 3.11.0rc1).
 
 - Disable unsafe math optimizations in C code.  See `pull request 25
   <https://github.com/zopefoundation/zope.hookable/pull/25>`_.

--- a/src/zope/hookable/tests/test_compile_flags.py
+++ b/src/zope/hookable/tests/test_compile_flags.py
@@ -1,0 +1,29 @@
+##############################################################################
+#
+# Copyright (c) 2022 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+import struct
+import unittest
+
+import zope.hookable  # noqa: try to load a C module for side effects
+
+
+class TestFloatingPoint(unittest.TestCase):
+
+    def test_no_fast_math_optimization(self):
+        # Building with -Ofast enables -ffast-math, which sets certain FPU
+        # flags that can cause breakage elsewhere.  A library such as BTrees
+        # has no business changing global FPU flags for the entire process.
+        zero_bits = struct.unpack("!Q", struct.pack("!d", 0.0))[0]
+        next_up = zero_bits + 1
+        smallest_subnormal = struct.unpack("!d", struct.pack("!Q", next_up))[0]
+        self.assertNotEqual(smallest_subnormal, 0.0)

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,9 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = true
+pip_pre = py311: true
 deps =
-    # repoze.sphinx.autointerface does not yet support Sphinx >= 5:
-    Sphinx < 5
+    Sphinx
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy-!pypy3: PURE_PYTHON=0


### PR DESCRIPTION
Add a regression test for CFLAGS not having -Ofast, which is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.