### PR TITLE
fix: detection of PURE_PYTHON where environ sets '0'

### DIFF
--- a/src/zope/hookable/__init__.py
+++ b/src/zope/hookable/__init__.py
@@ -18,7 +18,7 @@ import platform
 
 
 _PYPY = platform.python_implementation() in ('PyPy', 'Jython')
-_PURE_PYTHON = os.environ.get('PURE_PYTHON', _PYPY)
+_PURE_PYTHON = os.environ.get('PURE_PYTHON') == '1'
 
 
 class _py_hookable:
@@ -69,7 +69,7 @@ try:
 except ImportError:  # pragma: no cover
     _c_hookable = None
 
-if _PURE_PYTHON or _c_hookable is None:
+if _PYPY or _PURE_PYTHON or _c_hookable is None:
     hookable = _py_hookable
 else:  # pragma: no cover
     hookable = _c_hookable

--- a/src/zope/hookable/__init__.py
+++ b/src/zope/hookable/__init__.py
@@ -17,7 +17,11 @@ import os
 import platform
 
 
-_PYPY = platform.python_implementation() in ('PyPy', 'Jython')
+# Keep these two flags separate:  we want the `_PURE_PYTHON` one
+# to represent that the flag is explicitly set to '1' in the environment,
+# since our 'tox.ini' sets it to '0' for its environments which expect
+# to test the C extension.
+_PYPY_OR_JAVA = platform.python_implementation() in ('PyPy', 'Jython')
 _PURE_PYTHON = os.environ.get('PURE_PYTHON') == '1'
 
 
@@ -69,7 +73,7 @@ try:
 except ImportError:  # pragma: no cover
     _c_hookable = None
 
-if _PYPY or _PURE_PYTHON or _c_hookable is None:
+if _PYPY_OR_JAVA or _PURE_PYTHON or _c_hookable is None:
     hookable = _py_hookable
 else:  # pragma: no cover
     hookable = _c_hookable

--- a/src/zope/hookable/tests/test_hookable.py
+++ b/src/zope/hookable/tests/test_hookable.py
@@ -49,11 +49,16 @@ class PyHookableTests(PyHookableMixin,
                       unittest.TestCase):
 
     def test_pure_python(self):
+        from zope.hookable import _PYPY_OR_JAVA
         from zope.hookable import _PURE_PYTHON
         from zope.hookable import _c_hookable
         from zope.hookable import _py_hookable
         from zope.hookable import hookable
-        self.assertIs(hookable, _py_hookable if _PURE_PYTHON else _c_hookable)
+
+        if _PYPY_OR_JAVA or _PURE_PYTHON:
+            self.assertIs(hookable, _py_hookable)
+        else:
+            self.assertIs(hookable, _c_hookable)
 
     def test_before_hook(self):
         hooked = self._callFUT(return_foo)


### PR DESCRIPTION
E.g., our current 'tox.ini' does this, which effectively disables testing the C extension.