### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-7.1 (unreleased)
+8.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 8.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 - Add preliminary support for Python 3.14.

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,10 @@ setup(name='zope.hookable',
       cmdclass={
           'build_ext': optional_build_ext,
       },
+      # we need the following two parameters because we compile C code,
+      # otherwise only the shared library is installed:
+      package_dir={'': 'src'},
+      packages=['zope.hookable'],
       install_requires=[
           'setuptools',
       ],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ from distutils.errors import DistutilsExecError
 from distutils.errors import DistutilsPlatformError
 
 from setuptools import Extension
-from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
@@ -81,7 +80,7 @@ else:
 
 TESTS_REQUIRE = [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(name='zope.hookable',
@@ -115,9 +114,6 @@ setup(name='zope.hookable',
       cmdclass={
           'build_ext': optional_build_ext,
       },
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       install_requires=[
           'setuptools',
       ],

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ TESTS_REQUIRE = [
 ]
 
 setup(name='zope.hookable',
-      version='7.1.dev0',
+      version='8.0.dev0',
       url='http://github.com/zopefoundation/zope.hookable',
       license='ZPL-2.1',
       description='Zope hookable',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
- **Add needed packages.**
