### PR TITLE
Remove obsolete setuptools runtime dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 8.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Remove unnecessary ``setuptools`` runtime dependency.
 
 
 8.0 (2025-09-12)

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,6 @@ setup(name='zope.hookable',
       # otherwise only the shared library is installed:
       package_dir={'': 'src'},
       packages=['zope.hookable'],
-      install_requires=[
-          'setuptools',
-      ],
       include_package_data=True,
       zip_safe=False,
       extras_require={


### PR DESCRIPTION
The runtime dependency on `setuptools` was only required for namespace support.  Since `pkg_resources`-style namespaces have been removed and there are no relevant imports left in the code, remove the unnecessary dependency.

- [ ] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.
